### PR TITLE
feat: ボタンの新しいスタイルを追加およびバージョン更新

### DIFF
--- a/src/content/index.css
+++ b/src/content/index.css
@@ -68,6 +68,34 @@
     background-color: #e6f0f7;
 }
 
+/* Button styles for data-v-555ccef1 */
+.button[data-v-555ccef1] {
+    align-items: center;
+    background: #232425;
+    border: 1px solid #eaeaea;
+    border-radius: 8px;
+    box-sizing: border-box;
+    color: #fff;
+    display: flex;
+    flex-direction: row;
+    font-family: Inter;
+    font-size: 12px;
+    font-weight: 400;
+    gap: 8px;
+    height: 34px;
+    justify-content: center;
+    letter-spacing: 0;
+    line-height: 20px;
+    text-align: center;
+    vertical-align: middle;
+    width: 142px;
+    transition: all .3s ease;
+}
+
+.button[data-v-555ccef1]:hover {
+    opacity: 0.9;
+}
+
 /* Copy button styles */
 .copy-cell-button {
     display: flex;
@@ -77,10 +105,6 @@
     color: #1a73e8;
     border-radius: 4px;
     margin-top: 4px;
-}
-
-.copy-cell-button:hover {
-    background-color: rgba(26, 115, 232, 0.1);
 }
 
 .copy-cell-button svg {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GenSpark Export",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Adds export functionality to GenSpark AI application",
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
新しいデザイン仕様に基づき、ボタンにカスタムスタイルを追加しました。
- ボタンの背景色、境界線、フォントなどのスタイルを定義
- ホバー時のトランジション効果を実装 また、manifest.json内でアプリのバージョンを1.2.2に更新しました。

関連する影響範囲を確認の上、適用してください。